### PR TITLE
Testes unitários stores

### DIFF
--- a/src/stores/auth/index.spec.ts
+++ b/src/stores/auth/index.spec.ts
@@ -1,0 +1,66 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAuthStore } from './index';
+
+describe('auth store', () => {
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: vi.fn((key) => store[key] || null),
+      setItem: vi.fn((key, value) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key) => {
+        delete store[key];
+      }),
+      clear: () => {
+        store = {};
+      }
+    };
+  })();
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  it('sets token and stores in localStorage', () => {
+    const store = useAuthStore();
+    store.setToken('abc123');
+
+    expect(store.token).toBe('abc123');
+    expect(localStorage.setItem).toHaveBeenCalledWith('token', 'abc123');
+  });
+
+  it('sets user and stores in localStorage', () => {
+    const store = useAuthStore();
+    const mockUser = { name: 'Test', email: 'test@example.com', picture: 'pic.jpg' };
+
+    store.setUser(mockUser);
+
+    expect(store.user).toEqual(mockUser);
+    expect(localStorage.setItem).toHaveBeenCalledWith('user', JSON.stringify(mockUser));
+  });
+
+  it('logout clears token and user', () => {
+    const store = useAuthStore();
+    store.setToken('abc123');
+    store.setUser({ name: 'Test', email: 'test@example.com', picture: 'pic.jpg' });
+
+    store.logout();
+
+    expect(store.token).toBe('');
+    expect(store.user).toBe(null);
+    expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+    expect(localStorage.removeItem).toHaveBeenCalledWith('user');
+  });
+
+  it('isAuthenticated returns true only when token exists', () => {
+    const store = useAuthStore();
+    expect(store.isAuthenticated).toBe(false);
+
+    store.setToken('valid-token');
+    expect(store.isAuthenticated).toBe(true);
+  });
+});

--- a/src/stores/gameStore/index.spec.ts
+++ b/src/stores/gameStore/index.spec.ts
@@ -1,0 +1,36 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from './index';
+
+describe('gameStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should start the game', () => {
+    const store = useGameStore();
+    store.startGame();
+    expect(store.isGameStarted).toBe(true);
+  });
+
+  it('should finish the game and record time and attempts', () => {
+    const store = useGameStore();
+    store.finishGame(150, 8);
+
+    expect(store.timeElapsed).toBe(150);
+    expect(store.attempts).toBe(8);
+    expect(store.gameFinished).toBe(true);
+  });
+
+  it('should restart the game and reset state', () => {
+    const store = useGameStore();
+    store.startGame();
+    store.finishGame(200, 10);
+    store.restartGame();
+
+    expect(store.isGameStarted).toBe(false);
+    expect(store.gameFinished).toBe(false);
+    expect(store.timeElapsed).toBe(0);
+    expect(store.attempts).toBe(0);
+  });
+});

--- a/src/stores/memoryBoardStore/index.spec.ts
+++ b/src/stores/memoryBoardStore/index.spec.ts
@@ -1,0 +1,76 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMemoryBoardStore } from './index';
+
+describe('memoryBoardStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should start game and reset values', () => {
+    const store = useMemoryBoardStore();
+    store.startGame();
+
+    expect(store.gameStarted).toBe(true);
+    expect(store.attempts).toBe(0);
+    expect(store.timeElapsed).toBe(0);
+    expect(store.flippedCards).toEqual([]);
+    expect(store.matchedCards).toEqual([]);
+  });
+
+  it('should finish game and record time and attempts', () => {
+    const store = useMemoryBoardStore();
+    store.finishGame(180, 7);
+
+    expect(store.timeElapsed).toBe(180);
+    expect(store.attempts).toBe(7);
+  });
+
+  it('should reset game state', () => {
+    const store = useMemoryBoardStore();
+    store.startGame();
+    store.flipCard(1);
+    store.resetGame();
+
+    expect(store.flippedCards).toEqual([]);
+    expect(store.matchedCards).toEqual([]);
+    expect(store.attempts).toBe(0);
+    expect(store.timeElapsed).toBe(0);
+    expect(store.gameStarted).toBe(false);
+  });
+
+  it('should flip a card if valid', () => {
+    const store = useMemoryBoardStore();
+    store.matchedCards = [0];
+    store.flippedCards = [];
+
+    store.flipCard(1);
+
+    expect(store.flippedCards).toContain(1);
+  });
+
+  it('should not flip an already flipped or matched card', () => {
+    const store = useMemoryBoardStore();
+    store.flippedCards = [1];
+    store.matchedCards = [2];
+
+    store.flipCard(1);
+    store.flipCard(2);
+    store.flipCard(3);
+
+    expect(store.flippedCards).toContain(3);
+    expect(store.flippedCards).not.toContain(2);
+  });
+
+  it('should add matched cards', () => {
+    const store = useMemoryBoardStore();
+    store.addMatchedCards([2, 5]);
+    expect(store.matchedCards).toEqual([2, 5]);
+  });
+
+  it('should increment attempts', () => {
+    const store = useMemoryBoardStore();
+    store.incrementAttempts();
+    expect(store.attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
 Adicionados testes unitários completos para os stores: auth, gameStore e memoryBoardStore usando Pinia + Vitest.
🔍 Cobertura inclui ações de autenticação (setToken, setUser, logout), controle de estado do jogo (startGame, finishGame, restartGame) e lógica de tabuleiro (flipCard, addMatchedCards, incrementAttempts).
🧪 Mock de localStorage aplicado onde necessário e validações de mutação de estado e efeitos colaterais.